### PR TITLE
Bugfix: keyboardFocusedPair was not being cleared on widget destruction.

### DIFF
--- a/src/ColibriGui/ColibriManager.cpp
+++ b/src/ColibriGui/ColibriManager.cpp
@@ -702,6 +702,8 @@ namespace Colibri
 	{
 		if( widget == m_cursorFocusedPair.widget )
 			m_cursorFocusedPair.widget = 0;
+		if( widget == m_keyboardFocusedPair.widget )
+			m_keyboardFocusedPair.widget = 0;
 
 		if( widget->isWindow() )
 		{

--- a/src/ColibriGui/ColibriWindow.cpp
+++ b/src/ColibriGui/ColibriWindow.cpp
@@ -203,7 +203,8 @@ namespace Colibri
 	{
 		const size_t idx = Widget::notifyParentChildIsDestroyed( childWidgetBeingRemoved );
 
-		if( m_defaultChildWidget >= idx )
+		//If removing the child at index 0, keep the default as 0 rather than trying to subtract it.
+		if( m_defaultChildWidget >= idx && m_defaultChildWidget != 0 )
 			--m_defaultChildWidget;
 
 		return idx;


### PR DESCRIPTION
Using Colibri in my project I noticed crashes when destroying widgets in a window.
If the target widget was focused by the keyboard upon its destruction, the code would reach segfaults, as the keyboardFocusedPair pointer had not been cleared.
Secondly, removing the widget at index 0 in the window would cause m_defaultChildWidget to be decremented and wrap around to a large number, eventually causing nonsense pointers to be read from lists.