### PR TITLE
Bugfixes: solved crashing issues with widget destruction

### DIFF
--- a/src/ColibriGui/ColibriManager.cpp
+++ b/src/ColibriGui/ColibriManager.cpp
@@ -707,6 +707,17 @@ namespace Colibri
 		if( widget == m_keyboardFocusedPair.widget )
 			m_keyboardFocusedPair.widget = 0;
 
+		//If a widget was created and destroyed before update was called, there would still be some entries for that widget's labels in the dirty labels list.
+		//When update is later called it would read invalid pointers. Calling this here prevents that.
+		_updateDirtyLabels();
+
+		//Make sure this widget is not in the dirtyWidgets list.
+		WidgetVec::iterator itor = std::find( m_dirtyWidgets.begin(), m_dirtyWidgets.end(), widget );
+		if( itor != m_dirtyWidgets.end() )
+		{
+			m_dirtyWidgets.erase( itor );
+		}
+
 		if( widget->isWindow() )
 		{
 			COLIBRI_ASSERT( dynamic_cast<Window*>( widget ) );

--- a/src/ColibriGui/ColibriManager.cpp
+++ b/src/ColibriGui/ColibriManager.cpp
@@ -678,6 +678,8 @@ namespace Colibri
 	{
 		if( window == m_cursorFocusedPair.window )
 			m_cursorFocusedPair = FocusPair();
+		if( window == m_keyboardFocusedPair.window )
+			m_keyboardFocusedPair = FocusPair();
 
 		if( !window->m_parent )
 		{


### PR DESCRIPTION
Firstly, I overlooked that destroyWindow also needs to clear the keyboardFocusedPair in my last PR.

Secondly, I noticed a crash if you create a widget, and destroy it before a chance to call update. Calling update clears the dirty labels and dirty widgets, and widgets insert values into this on creation (or other stuff). If update is not called before the widget is destroyed then these pointers remain in the list after they've been destroyed, eventually causing a crash when update is later called. 
To solve this I've made a call to _updateDirtyLabels each time a widget is destroyed. This crash is quite an uncommon occurrence (it was found by automated testing), so most of the time this function would just loop through an empty list and do nothing, so no real performance drain.
Finally, the dirty widgets list has to be checked for the pointer targeted for deletion, as it's about to become invalid.