### PR TITLE
Bugfix: Added a call to updateDirtyLabels if backspace was pressed

### DIFF
--- a/src/ColibriGui/ColibriEditbox.cpp
+++ b/src/ColibriGui/ColibriEditbox.cpp
@@ -168,6 +168,8 @@ namespace Colibri
 				std::string result;
 				uStr.toUTF8String( result );
 				m_label->setText( result );
+
+				m_manager->_updateDirtyLabels();
 			}
 
 			showCaret();

--- a/src/ColibriGui/ColibriManager.cpp
+++ b/src/ColibriGui/ColibriManager.cpp
@@ -707,8 +707,9 @@ namespace Colibri
 		if( widget == m_keyboardFocusedPair.widget )
 			m_keyboardFocusedPair.widget = 0;
 
-		//If a widget was created and destroyed before update was called, there would still be some entries for that widget's labels in the dirty labels list.
-		//When update is later called it would read invalid pointers. Calling this here prevents that.
+		// If a widget was created and destroyed before update was called, there would still be some
+		// entries for that widget's labels in the dirty labels list. When update is later called it
+		// would read invalid pointers. Calling this here prevents that.
 		_updateDirtyLabels();
 
 		//Make sure this widget is not in the dirtyWidgets list.


### PR DESCRIPTION
It seems like ColibriEditbox setTextSpecialKey was missing a call to update dirty labels. As the string has changed thanks to the backspace / delete key the labels need to be updated. Editbox::_setTextInput does a similar thing.

Specifically I found that if the timeSinceLastFrame passed to ColibriManager update was big, the backspace command would be repeated in a loop the correct number of times. However, if it was performed twice or more assertions would be hit as the main update loop didn't have a chance to update the dirty labels. This fixes that.