### PR TITLE
Ported to metal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ src/OgreCommon/
 
 Dependencies/Ogre
 Dependencies/build_result/
+
+.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,10 +3,14 @@
 # In Windows you built Ogre into Dependencies/Ogre/build
 # In Linux you built Release into Dependencies/Ogre/build/Release
 # In Linux you built Debug into Dependencies/Ogre/build/Debug
+# In MacOS you did the same as Linux, and didn't build Ogre as frameworks.
 #
 # If your source code is not at "Dependencies/Ogre"; you can use "mklink /D" to create
 # a symbolic link to where the source code is located on Windows.
 # On Linux, you can use "ln -s"
+
+#If you get errors finding doxygen, i.e 'Could NOT find Doxygen (missing: dot)', you need to install graphviz, as well as doxygen
+#apt install graphviz, brew install graphviz
 
 #set( CMAKE_TOOLCHAIN_FILE CMake/iOS.cmake )
 
@@ -55,20 +59,43 @@ if( MSVC90 )
 endif()
 
 if( NOT COLIBRIGUI_LIB_ONLY )
-	add_recursive( ./src SOURCES )
-	add_recursive( ./include HEADERS )
+	#add_recursive( ./src SOURCES )
+	#add_recursive( ./include HEADERS )
+
+	#add_recursive( ./src/OgreCommon/System/OSX/*.mm SOURCES )
+
+	#add_recursive would have added all .mm files, including the ios ones. We need to be able to set specifics.
+	file(GLOB_RECURSE SOURCES "src/*.cpp")
+	file(GLOB_RECURSE HEADERS "include/*.h")
+	if( APPLE )
+		file(GLOB_RECURSE MMSOURCES "src/OgreCommon/System/OSX/*.mm")
+	endif()
+
 else()
 	add_recursive( ./src/ColibriGui SOURCES )
 	add_recursive( ./include/ColibriGui HEADERS )
 endif()
 
 if( APPLE )
-	file( GLOB_RECURSE RESOURCES ./src/*.storyboard )
-	set( RESOURCES ${RESOURCES} ./Data/Resources.cfg ./bin/Data )
+	set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++11")
+	set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
+	set(CMAKE_CXX_FLAGS "-x objective-c++")
+
+	#Set the pluginFolder path in the plugins.cfg file.
+	#Make a copy of the original one so it can be edited.
+	execute_process(COMMAND "cp" "${OGRE_BINARIES}/bin/plugins.cfg" "/tmp/plugins.cfg")
+	execute_process(COMMAND bash -c "/usr/bin/sed -i '' 's#PluginFolder=#PluginFolder=${OGRE_BINARIES}/lib/macosx/${CMAKE_BUILD_TYPE}/#g' /tmp/plugins.cfg")
+
+	#file( GLOB_RECURSE RESOURCES ./src/*.storyboard )
+	set( RESOURCES ${RESOURCES} ./bin/Data "./bin/Data/resourcesMac/resources2.cfg" "/tmp/plugins.cfg" "${OGRE_SOURCE}/Samples/Media/")
 endif()
 
 if( NOT COLIBRIGUI_LIB_ONLY )
-	add_executable( ${PROJECT_NAME} WIN32 MACOSX_BUNDLE ${SOURCES} ${HEADERS} ${RESOURCES} )
+	if( APPLE )
+		add_executable( ${PROJECT_NAME} WIN32 MACOSX_BUNDLE ${SOURCES} ${HEADERS} ${MMSOURCES} ${RESOURCES} )
+	else()
+		add_executable( ${PROJECT_NAME} WIN32 MACOSX_BUNDLE ${SOURCES} ${HEADERS} ${RESOURCES} )
+	endif()
 else()
 	add_library( ${PROJECT_NAME} STATIC ${SOURCES} ${HEADERS} )
 endif()
@@ -83,9 +110,25 @@ endif()
 if( APPLE )
 	set_target_properties( ${PROJECT_NAME} PROPERTIES XCODE_ATTRIBUTE_ENABLE_BITCODE "NO" )
 	set_target_properties( ${PROJECT_NAME} PROPERTIES RESOURCE "${RESOURCES}" )
-	set_target_properties( ${PROJECT_NAME} PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/src/Info.plist )
+	set_target_properties( ${PROJECT_NAME} PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/src/OgreCommon/System/OSX/Resources/Info.plist )
 	#set_target_properties( ${PROJECT_NAME} PROPERTIES MACOSX_BUNDLE_ICON_FILE SampleBrowser_OSX.icns)
-	set( CMAKE_EXE_LINKER_FLAGS "-framework Foundation -framework CoreGraphics -framework QuartzCore -framework UIKit -framework Metal -framework MetalKit -framework ModelIO" )
+	#set( CMAKE_EXE_LINKER_FLAGS "-framework Foundation -framework CoreGraphics -framework QuartzCore -framework UIKit -framework Metal -framework MetalKit -framework ModelIO" )
+	#set( CMAKE_EXE_LINKER_FLAGS "-framework Foundation -framework CoreGraphics -framework IOKit -framework CoreAudio -framework QuartzCore -framework Metal -framework MetalKit -framework ModelIO" )
+	set( CMAKE_EXE_LINKER_FLAGS "
+		-framework AudioToolbox
+		-framework CoreAudio
+		-framework CoreVideo
+		-framework CoreFoundation
+		-framework Carbon
+		-framework Cocoa
+		-framework IOKit
+		-framework ForceFeedback
+		-framework QuartzCore
+		-framework Metal
+		-framework OpenGL
+	")
+
+
 endif()
 
 if( ${CMAKE_VERSION} VERSION_GREATER 3.9 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,14 +115,6 @@ if( APPLE )
 	#set( CMAKE_EXE_LINKER_FLAGS "-framework Foundation -framework CoreGraphics -framework QuartzCore -framework UIKit -framework Metal -framework MetalKit -framework ModelIO" )
 	#set( CMAKE_EXE_LINKER_FLAGS "-framework Foundation -framework CoreGraphics -framework IOKit -framework CoreAudio -framework QuartzCore -framework Metal -framework MetalKit -framework ModelIO" )
 	set( CMAKE_EXE_LINKER_FLAGS "
-		-framework AudioToolbox
-		-framework CoreAudio
-		-framework CoreVideo
-		-framework CoreFoundation
-		-framework Carbon
-		-framework Cocoa
-		-framework IOKit
-		-framework ForceFeedback
 		-framework QuartzCore
 		-framework Metal
 		-framework OpenGL

--- a/bin/Data/Hlms/Colibri/Any/ColibriGui_piece_all.any
+++ b/bin/Data/Hlms/Colibri/Any/ColibriGui_piece_all.any
@@ -5,11 +5,6 @@
 		float2 uvText @property( syntax == hlsl ): TEXCOORD@counter(texcoord)@end ;
 		NO_INTERPOLATION_PREFIX uint glyphOffsetStart	NO_INTERPOLATION_SUFFIX @property( syntax == hlsl ): TEXCOORD@counter(texcoord)@end ;
 		NO_INTERPOLATION_PREFIX uint pixelsPerRow		NO_INTERPOLATION_SUFFIX @property( syntax == hlsl ): TEXCOORD@counter(texcoord)@end ;
-
-		float gl_ClipDistance0;
-		float gl_ClipDistance1;
-		float gl_ClipDistance2;
-		float gl_ClipDistance3;
 	@end
 @end
 

--- a/bin/Data/Hlms/Colibri/Any/ColibriGui_piece_all.any
+++ b/bin/Data/Hlms/Colibri/Any/ColibriGui_piece_all.any
@@ -5,6 +5,11 @@
 		float2 uvText @property( syntax == hlsl ): TEXCOORD@counter(texcoord)@end ;
 		NO_INTERPOLATION_PREFIX uint glyphOffsetStart	NO_INTERPOLATION_SUFFIX @property( syntax == hlsl ): TEXCOORD@counter(texcoord)@end ;
 		NO_INTERPOLATION_PREFIX uint pixelsPerRow		NO_INTERPOLATION_SUFFIX @property( syntax == hlsl ): TEXCOORD@counter(texcoord)@end ;
+
+		float gl_ClipDistance0;
+		float gl_ClipDistance1;
+		float gl_ClipDistance2;
+		float gl_ClipDistance3;
 	@end
 @end
 

--- a/bin/Data/Hlms/Colibri/Any/ColibriGui_piece_vs.metal
+++ b/bin/Data/Hlms/Colibri/Any/ColibriGui_piece_vs.metal
@@ -9,15 +9,6 @@
 	@end
 @end
 
-@property( colibri_text == 0 )
-	@piece( custom_VStoPS )
-		float gl_ClipDistance0;
-		float gl_ClipDistance1;
-		float gl_ClipDistance2;
-		float gl_ClipDistance3;
-	@end
-@end
-
 @piece( custom_vs_uniformDeclaration )
 	, uint gl_VertexID	[[vertex_id]]
 @end
@@ -31,10 +22,10 @@
 
 	#define worldViewProj 1.0f
 
-	outVs.gl_ClipDistance0 = input.normal.x;
-	outVs.gl_ClipDistance1 = input.normal.y;
-	outVs.gl_ClipDistance2 = input.normal.z;
-	outVs.gl_ClipDistance3 = input.normal.w;
+	outVs.gl_ClipDistance0[0] = input.normal.x;
+	outVs.gl_ClipDistance0[1] = input.normal.y;
+	outVs.gl_ClipDistance0[2] = input.normal.z;
+	outVs.gl_ClipDistance0[3] = input.normal.w;
 
 	@property( colibri_text )
 		uint vertId = (uint(gl_VertexID) - worldMaterialIdx[drawId].w) % 6u;

--- a/bin/Data/Hlms/Colibri/Any/ColibriGui_piece_vs.metal
+++ b/bin/Data/Hlms/Colibri/Any/ColibriGui_piece_vs.metal
@@ -22,10 +22,10 @@
 
 	#define worldViewProj 1.0f
 
-	outVs.gl_ClipDistance0[0] = input.normal.x;
-	outVs.gl_ClipDistance0[1] = input.normal.y;
-	outVs.gl_ClipDistance0[2] = input.normal.z;
-	outVs.gl_ClipDistance0[3] = input.normal.w;
+	outVs.gl_ClipDistance[0] = input.normal.x;
+	outVs.gl_ClipDistance[1] = input.normal.y;
+	outVs.gl_ClipDistance[2] = input.normal.z;
+	outVs.gl_ClipDistance[3] = input.normal.w;
 
 	@property( colibri_text )
 		uint vertId = (uint(gl_VertexID) - worldMaterialIdx[drawId].w) % 6u;

--- a/bin/Data/Hlms/Colibri/Any/ColibriGui_piece_vs.metal
+++ b/bin/Data/Hlms/Colibri/Any/ColibriGui_piece_vs.metal
@@ -1,0 +1,48 @@
+@property( colibri_gui )
+
+@piece( custom_vs_attributes )
+	float4 normal [[attribute(VES_NORMAL)]];
+
+	@property( colibri_text )
+		uint tangent [[attribute(VES_TANGENT)]];
+		uint2 blendIndices [[attribute(VES_BLEND_INDICES)]];
+	@end
+@end
+
+@property( colibri_text == 0 )
+	@piece( custom_VStoPS )
+		float gl_ClipDistance0;
+		float gl_ClipDistance1;
+		float gl_ClipDistance2;
+		float gl_ClipDistance3;
+	@end
+@end
+
+@piece( custom_vs_uniformDeclaration )
+	, uint gl_VertexID	[[vertex_id]]
+@end
+
+@piece( custom_vs_preExecution )
+	@property( !colibri_text )
+		uint colibriDrawId = drawId + ((uint(gl_VertexID) - worldMaterialIdx[drawId].w) / 54u);
+		#undef finalDrawId
+		#define finalDrawId colibriDrawId
+	@end
+
+	#define worldViewProj 1.0f
+
+	outVs.gl_ClipDistance0 = input.normal.x;
+	outVs.gl_ClipDistance1 = input.normal.y;
+	outVs.gl_ClipDistance2 = input.normal.z;
+	outVs.gl_ClipDistance3 = input.normal.w;
+
+	@property( colibri_text )
+		uint vertId = (uint(gl_VertexID) - worldMaterialIdx[drawId].w) % 6u;
+		outVs.uvText.x = (vertId <= 1u || vertId == 5u) ? 0.0f : float( input.blendIndices.x );
+		outVs.uvText.y = (vertId == 0u || vertId >= 4u) ? 0.0f : float( input.blendIndices.y );
+		outVs.pixelsPerRow		= input.blendIndices.x;
+		outVs.glyphOffsetStart	= input.tangent;
+	@end
+@end
+
+@end

--- a/bin/Data/resourcesMac/resources2.cfg
+++ b/bin/Data/resourcesMac/resources2.cfg
@@ -1,0 +1,16 @@
+[Essential]
+Zip=Contents/Resources/Data/DebugPack.zip
+
+[Popular]
+FileSystem=Contents/Resources/Data
+FileSystem=Contents/Resources/Data/Materials/Common
+FileSystem=Contents/Resources/Data/Materials/Common/GLSL
+FileSystem=Contents/Resources/Data/Materials/Common/HLSL
+FileSystem=Contents/Resources/Data/Materials/Common/Metal
+FileSystem=Contents/Resources/Data/Materials/ColibriGui/Skins/DarkGloss
+FileSystem=Contents/Resources/Data/Materials/ColibriGui/Skins/Debug
+
+# Do not load this as a resource. It's here merely to tell the code where
+# the Hlms templates are located
+[Hlms]
+DoNotUseAsResource=Contents/Resources/Data


### PR DESCRIPTION
<img width="1334" alt="Screen Shot 2020-04-23 at 17 30 55" src="https://user-images.githubusercontent.com/4259278/80124621-6bde5200-8588-11ea-8e66-adffc1aa85d2.png">

Wrote the leftover metal shaders, updated the build system to include MacOS, added any checks the actual code needs to do to get the application running. This includes both the sample and the build-as-library option. Most of this work is getting the sample to work though.

Here are a few things I think are worth mentioning:
- This doesn't include ios support. My project is only interested in the mac. I noticed some ios specific stuff in the build system, but I assumed that was just copy and pasted from the samples and wasn't being actively used / maintained. It might work but I haven't tried it.
- I had problems getting ogre built as frameworks to work with this. Dynlib and static builds work. There's no real reason why frameworks wouldn't work, it's just that it would involve some potentially messy changes to the build system. I had some problems getting the ogre cmake stuff to do what I wanted. 
- I ran into a build issue with clang in one of the ogre headers. After lots of trying the only solution I found was a line which enables c++11 in apple builds. I can give more details of this problem if you'd like. Colibri is meant to be c++ 98, but this just enables it for compilation, not effecting the code, so hopefully it fixes the problem and that's fine.
- The example has some slight work arounds for resource paths. This is mostly a symptom of application bundles in MacOS and the confliction with the ../Data approach as the resources directory used in the other platforms. 

This branch has also been tested on Windows and Linux, and builds and works the same as before.

Thanks!