### PR TITLE
Added a user value to ColibriWidget.

### DIFF
--- a/include/ColibriGui/ColibriWidget.h
+++ b/include/ColibriGui/ColibriWidget.h
@@ -127,6 +127,9 @@ namespace Colibri
 		/// @see	Widget::isUltimatelyBreadthFirst
 		bool m_breadthFirst;
 
+		/// A value for any sort of use. Colibri does not use it in any way.
+		Ogre::uint64 m_UserId;
+
 	protected:
 		States::States			m_currentState;
 

--- a/include/ColibriGui/ColibriWidget.h
+++ b/include/ColibriGui/ColibriWidget.h
@@ -128,7 +128,7 @@ namespace Colibri
 		bool m_breadthFirst;
 
 		/// A value for any sort of use. Colibri does not use it in any way.
-		Ogre::uint64 m_UserId;
+		uint64_t m_userId;
 
 	protected:
 		States::States			m_currentState;

--- a/src/ColibriGui/ColibriWidget.cpp
+++ b/src/ColibriGui/ColibriWidget.cpp
@@ -29,6 +29,7 @@ namespace Colibri
 		m_pressable( true ),
 		m_culled( false ),
 		m_breadthFirst( false ),
+		m_UserId( 0 ),
 		m_currentState( States::Idle ),
 		m_position( Ogre::Vector2::ZERO ),
 		m_size( Ogre::Vector2::ZERO ),

--- a/src/ColibriGui/ColibriWidget.cpp
+++ b/src/ColibriGui/ColibriWidget.cpp
@@ -29,7 +29,7 @@ namespace Colibri
 		m_pressable( true ),
 		m_culled( false ),
 		m_breadthFirst( false ),
-		m_UserId( 0 ),
+		m_userId( 0 ),
 		m_currentState( States::Idle ),
 		m_position( Ogre::Vector2::ZERO ),
 		m_size( Ogre::Vector2::ZERO ),


### PR DESCRIPTION
This is a simple value for the user to populate. Recently I've been integrating Colibri with a scripting language, and I need a way to store my own ids in widgets. Many similar libraries offer a similar thing.

Technically I could have used the Ogre::Any variable if casted to a Colibri::Renderable, but I think it's better to have it as far down the inheritance hierarchy as possible. 