### PR TITLE
Made the mouse cursor visible in the demo.

### DIFF
--- a/src/ColibriGuiGameState.cpp
+++ b/src/ColibriGuiGameState.cpp
@@ -301,6 +301,7 @@ namespace Demo
 			SdlInputHandler *inputHandler = mGraphicsSystem->getInputHandler();
 			inputHandler->setGrabMousePointer( false );
 			inputHandler->setMouseVisible( true );
+			inputHandler->setMouseRelative( false );
 			tried = true;
 		}
 


### PR DESCRIPTION
On my computer the mouse cursor was invisible in the demo.

From some investigation I found that adding this line fixes that. Relative mouse mode is some sort of uber mouse grab.

https://wiki.libsdl.org/SDL_SetRelativeMouseMode