### PR TITLE
Added a slider widget.

### DIFF
--- a/bin/Data/Materials/ColibriGui/Skins/DarkGloss/Skins.colibri.json
+++ b/bin/Data/Materials/ColibriGui/Skins/DarkGloss/Skins.colibri.json
@@ -206,6 +206,8 @@
         "CheckboxTickmarkThirdState"    : "CheckboxTickmarkThirdState",
         "Editbox"               : "Button",
         "ProgressbarLayer0"     : "ProgressbarLayer0",
-        "ProgressbarLayer1"     : "ProgressbarLayer1"
+        "ProgressbarLayer1"     : "ProgressbarLayer1",
+        "SliderLine"            : "Button",
+        "SliderHandle"          : "Button"
     }
 }

--- a/bin/Data/Materials/ColibriGui/Skins/Debug/Skins.colibri.json
+++ b/bin/Data/Materials/ColibriGui/Skins/Debug/Skins.colibri.json
@@ -76,6 +76,8 @@
         "CheckboxTickmarkThirdState"    : "ButtonSkin",
         "Editbox"               : "ButtonSkin",
         "ProgressbarLayer0"     : "ButtonSkin",
-        "ProgressbarLayer1"     : "ButtonSkin"
+        "ProgressbarLayer1"     : "ButtonSkin",
+        "SliderLine"            : "ButtonSkin",
+        "SliderHandle"          : "ButtonSkin"
     }
 }

--- a/include/ColibriGui/ColibriGuiPrerequisites.h
+++ b/include/ColibriGui/ColibriGuiPrerequisites.h
@@ -373,6 +373,8 @@ namespace Colibri
 			Editbox,
 			ProgressbarLayer0,
 			ProgressbarLayer1,
+			SliderLine,
+			SliderHandle,
 			NumSkinWidgetTypes
 		};
 	}

--- a/include/ColibriGui/ColibriManager.h
+++ b/include/ColibriGui/ColibriManager.h
@@ -280,7 +280,12 @@ namespace Colibri
 	public:
 		void setKeyDirectionPressed( Borders::Borders direction );
 		void setKeyDirectionReleased( Borders::Borders direction );
-		void setScroll( const Ogre::Vector2 &scrollAmount );
+		/**
+		@return
+			True if the scroll was consumed by a widget.
+			False otherwise
+		*/
+		bool setScroll( const Ogre::Vector2 &scrollAmount );
 
 		/// For understanding these params, see SDL_TextEditingEvent
 		void setTextEdit( const char *text, int32_t selectStart, int32_t selectLength );

--- a/include/ColibriGui/ColibriSlider.h
+++ b/include/ColibriGui/ColibriSlider.h
@@ -26,6 +26,9 @@ namespace Colibri
 		Renderable *colibrigui_nullable m_layers[2];
 
 		float m_sliderValue;
+		/// When directional actions (keyboard buttons) are applied,
+		/// this is how much the slider value be increased or decreased.
+		float m_directionChangeAmount;
 
 	protected:
 
@@ -56,6 +59,10 @@ namespace Colibri
 		virtual void setTransformDirty( uint32_t dirtyReason ) colibri_final;
 
 		virtual void notifyCursorMoved( const Ogre::Vector2& posNDC );
+		virtual void _notifyActionKeyMovement( Borders::Borders direction );
+
+		float getDirectionChangeAmount() const { return m_directionChangeAmount; }
+		void setDirectionChangeAmount( float amount ) { m_directionChangeAmount = amount; }
 
 	private:
 		void _processCursorPosition( const Ogre::Vector2& pos );

--- a/include/ColibriGui/ColibriSlider.h
+++ b/include/ColibriGui/ColibriSlider.h
@@ -31,6 +31,7 @@ namespace Colibri
 		float m_directionChangeAmount;
 
 		float m_cursorOffset;
+		float m_handleSize;
 
 	protected:
 

--- a/include/ColibriGui/ColibriSlider.h
+++ b/include/ColibriGui/ColibriSlider.h
@@ -1,0 +1,60 @@
+
+#pragma once
+
+#include "ColibriGui/ColibriWidget.h"
+
+#include "OgreId.h"
+
+namespace Ogre
+{
+	class HlmsUnlitDatablock;
+}
+
+COLIBRIGUI_ASSUME_NONNULL_BEGIN
+
+namespace Colibri
+{
+	/** @ingroup Controls
+	@class Slider
+		Displays an interactive slider widget using two Renderables
+
+		Layer 0 is drawn behind layer 1
+	*/
+	class Slider colibri_final : public Widget, Ogre::IdObject
+	{
+	protected:
+		Renderable *colibrigui_nullable m_layers[2];
+
+		float m_sliderValue;
+
+	protected:
+
+		void updateSlider();
+
+	public:
+		Slider( ColibriManager *manager );
+
+		virtual void _initialize();
+		virtual void _destroy();
+
+		Renderable *getFrameLayer();
+		Renderable *getProgressLayer();
+
+		/// @copydoc Renderable::setVisualsEnabled
+		void         setVisualsEnabled( bool bEnabled );
+		virtual bool isVisualsEnabled() const colibri_final;
+
+		virtual void setState( States::States state, bool smartHighlight = true,
+							   bool broadcastEnable = false );
+
+		// Set the value of the slider. Right now this is between 0 and 1 only.
+		void setValue( float value );
+
+		Renderable *colibrigui_nullable getSliderLine();
+		Renderable *colibrigui_nullable getSliderHandle();
+
+		virtual void setTransformDirty( uint32_t dirtyReason ) colibri_final;
+	};
+}  // namespace Colibri
+
+COLIBRIGUI_ASSUME_NONNULL_END

--- a/include/ColibriGui/ColibriSlider.h
+++ b/include/ColibriGui/ColibriSlider.h
@@ -54,6 +54,11 @@ namespace Colibri
 		Renderable *colibrigui_nullable getSliderHandle();
 
 		virtual void setTransformDirty( uint32_t dirtyReason ) colibri_final;
+
+		virtual void notifyCursorMoved( const Ogre::Vector2& posNDC );
+
+	private:
+		void _processCursorPosition( const Ogre::Vector2& pos );
 	};
 }  // namespace Colibri
 

--- a/include/ColibriGui/ColibriSlider.h
+++ b/include/ColibriGui/ColibriSlider.h
@@ -54,6 +54,7 @@ namespace Colibri
 
 		// Set the value of the slider. Right now this is between 0 and 1 only.
 		void setValue( float value );
+		float getValue() const { return m_sliderValue; };
 
 		Renderable *colibrigui_nullable getSliderLine();
 		Renderable *colibrigui_nullable getSliderHandle();

--- a/include/ColibriGui/ColibriSlider.h
+++ b/include/ColibriGui/ColibriSlider.h
@@ -30,6 +30,8 @@ namespace Colibri
 		/// this is how much the slider value be increased or decreased.
 		float m_directionChangeAmount;
 
+		float m_cursorOffset;
+
 	protected:
 
 		void updateSlider();
@@ -65,7 +67,7 @@ namespace Colibri
 		void setDirectionChangeAmount( float amount ) { m_directionChangeAmount = amount; }
 
 	private:
-		void _processCursorPosition( const Ogre::Vector2& pos );
+		void _processCursorPosition( const Ogre::Vector2& pos, bool cursorBegin = false );
 	};
 }  // namespace Colibri
 

--- a/include/ColibriGui/ColibriWidget.h
+++ b/include/ColibriGui/ColibriWidget.h
@@ -517,6 +517,9 @@ namespace Colibri
 
 		ColibriManager *getManager();
 
+		/// Notify the widget that the cursor moved somewhere within its bounds.
+		virtual void notifyCursorMoved( const Ogre::Vector2& posNDC );
+
 		/**
 		@remarks
 			Do not assume derived top left <= derived bottom right.

--- a/include/ColibriGui/ColibriWidget.h
+++ b/include/ColibriGui/ColibriWidget.h
@@ -88,6 +88,9 @@ namespace Colibri
 		/// Whether this widget can go into States::Pressed state via keyboard or mouse cursor.
 		/// (assuming it is either clickable or keyboard navigable, otherwise it would be impossible)
 		bool					m_pressable;
+		/// If the cursor is interacting with this widget, no scroll can take place if this is true.
+		/// This is useful for widgets which require some sort of mouse movement to function.
+		bool					m_consumesScroll;
 
 		bool m_culled;
 	public:
@@ -209,6 +212,8 @@ namespace Colibri
 
 		void setPressable( bool pressable );
 		bool isPressable() const			{ return m_pressable; }
+
+		bool consumesScroll() const			{ return m_consumesScroll; }
 
 		void setHidden( bool hidden );
 		bool isHidden() const				{ return m_hidden; }

--- a/src/ColibriGui/ColibriManager.cpp
+++ b/src/ColibriGui/ColibriManager.cpp
@@ -374,6 +374,11 @@ namespace Colibri
 			}
 		}
 
+		if(focusedPair.widget){
+			//Notify the widget that the mouse moved.
+			focusedPair.widget->notifyCursorMoved( newPosNdc );
+		}
+
 		m_cursorFocusedPair = focusedPair;
 	}
 	//-------------------------------------------------------------------------

--- a/src/ColibriGui/ColibriManager.cpp
+++ b/src/ColibriGui/ColibriManager.cpp
@@ -391,11 +391,14 @@ namespace Colibri
 		if( m_allowingScrollGestureWhileButtonDown && (m_allowingScrollAlways ||
 			(m_cursorFocusedPair.window && m_cursorFocusedPair.window->hasScroll())) )
 		{
-			setCancel();
-			//setCancel changed m_allowingScrollGestureWhileButtonDown, so restore it
-			m_allowingScrollGestureWhileButtonDown = true;
-			setScroll( (oldPos - m_mouseCursorPosNdc) * 0.5f * m_canvasSize );
+			bool scrollConsumed = setScroll( (oldPos - m_mouseCursorPosNdc) * 0.5f * m_canvasSize );
 			//^^ setScroll will call updateWidgetsFocusedByCursor if necessary
+
+			if( !scrollConsumed ){
+				setCancel();
+				//setCancel changed m_allowingScrollGestureWhileButtonDown, so restore it
+				m_allowingScrollGestureWhileButtonDown = true;
+			}
 		}
 		else
 		{
@@ -584,17 +587,25 @@ namespace Colibri
 		}
 	}
 	//-------------------------------------------------------------------------
-	void ColibriManager::setScroll( const Ogre::Vector2 &scrollAmount )
+	bool ColibriManager::setScroll( const Ogre::Vector2 &scrollAmount )
 	{
 		Window *window = m_cursorFocusedPair.window;
 		if( window )
 		{
+			if( m_cursorFocusedPair.widget && m_cursorFocusedPair.widget->consumesScroll() )
+			{
+				//If the widget focused by the cursor consumes the scroll, just update and leave.
+				updateWidgetsFocusedByCursor();
+				return true;
+			}
 			window->setScrollAnimated( window->getNextScroll() + scrollAmount, true );
 
 			updateAllDerivedTransforms();
 			//If is possible the button we were highlighting is no longer behind the cursor
 			updateWidgetsFocusedByCursor();
 		}
+
+		return false;
 	}
 	//-------------------------------------------------------------------------
 	void ColibriManager::setTextEdit( const char *text, int32_t selectStart, int32_t selectLength )

--- a/src/ColibriGui/ColibriSkinManager.cpp
+++ b/src/ColibriGui/ColibriSkinManager.cpp
@@ -502,7 +502,9 @@ namespace Colibri
 			"CheckboxTickmarkThirdState",
 			"Editbox",
 			"ProgressbarLayer0",
-			"ProgressbarLayer1"
+			"ProgressbarLayer1",
+			"SliderLine",
+			"SliderHandle"
 		};
 
 		std::string defaultSkins[SkinWidgetTypes::NumSkinWidgetTypes];
@@ -645,4 +647,3 @@ namespace Colibri
 			loadDefaultSkinPacks( itTmp->value, filename );
 	}
 }
-

--- a/src/ColibriGui/ColibriSlider.cpp
+++ b/src/ColibriGui/ColibriSlider.cpp
@@ -152,7 +152,6 @@ namespace Colibri
 				{
 					// The user actually clicked on the handle, rather than part of the line.
 					// If this happens, apply an offset to the mouse movements, so the handle doesn't jump.
-					const Ogre::Vector2 widgetSize = getSize();
 					m_cursorOffset = posX - m_sliderValue;
 				}
 

--- a/src/ColibriGui/ColibriSlider.cpp
+++ b/src/ColibriGui/ColibriSlider.cpp
@@ -20,6 +20,7 @@ namespace Colibri
 
 		m_clickable = true;
 		m_keyboardNavigable = true;
+		m_consumesScroll = true;
 
 		m_autoSetNextWidget[Borders::Left] = false;
 		m_autoSetNextWidget[Borders::Right] = false;

--- a/src/ColibriGui/ColibriSlider.cpp
+++ b/src/ColibriGui/ColibriSlider.cpp
@@ -71,6 +71,11 @@ namespace Colibri
 	{
 		Widget::setState( state, smartHighlight, broadcastEnable );
 
+		if(state == States::Pressed)
+		{
+			_processCursorPosition( m_manager->getMouseCursorPosNdc() );
+		}
+
 		// Widget::setState did not re-enable children we control. Do it manually
 		if( !broadcastEnable )
 		{
@@ -122,6 +127,25 @@ namespace Colibri
 		}
 
 		Widget::setTransformDirty( dirtyReason );
+	}
+	//-------------------------------------------------------------------------
+	void Slider::_processCursorPosition( const Ogre::Vector2& pos ){
+		if( this->intersects( pos ) )
+		{
+			if(m_currentState == States::Pressed)
+			{
+				const float sliderWidth = m_derivedBottomRight.x - m_derivedTopLeft.x;
+				const float mouseRelativeX = pos.x - m_derivedTopLeft.x;
+
+				const float value = mouseRelativeX / sliderWidth;
+
+				setValue(value);
+			}
+		}
+	}
+	//-------------------------------------------------------------------------
+	void Slider::notifyCursorMoved( const Ogre::Vector2& posNDC ){
+		_processCursorPosition( posNDC );
 	}
 	//-------------------------------------------------------------------------
 	void Slider::setValue( float value )

--- a/src/ColibriGui/ColibriSlider.cpp
+++ b/src/ColibriGui/ColibriSlider.cpp
@@ -9,12 +9,16 @@ namespace Colibri
 	Slider::Slider( ColibriManager *manager ) :
 		Widget( manager ),
 		IdObject( Ogre::Id::generateNewId<Progressbar>() ),
-		m_sliderValue( 0.0f )
+		m_sliderValue( 0.0f ),
+		m_directionChangeAmount( 0.1f )
 	{
 		memset( m_layers, 0, sizeof( m_layers ) );
 
 		m_clickable = true;
 		m_keyboardNavigable = true;
+
+		m_autoSetNextWidget[Borders::Left] = false;
+		m_autoSetNextWidget[Borders::Right] = false;
 	}
 	//-------------------------------------------------------------------------
 	void Slider::_initialize()
@@ -146,6 +150,14 @@ namespace Colibri
 	//-------------------------------------------------------------------------
 	void Slider::notifyCursorMoved( const Ogre::Vector2& posNDC ){
 		_processCursorPosition( posNDC );
+	}
+	//-------------------------------------------------------------------------
+	void Slider::_notifyActionKeyMovement( Borders::Borders direction )
+	{
+		if( direction == Borders::Left )
+			setValue( m_sliderValue - m_directionChangeAmount );
+		else if( direction == Borders::Right )
+			setValue( m_sliderValue + m_directionChangeAmount );
 	}
 	//-------------------------------------------------------------------------
 	void Slider::setValue( float value )

--- a/src/ColibriGui/ColibriSlider.cpp
+++ b/src/ColibriGui/ColibriSlider.cpp
@@ -1,0 +1,136 @@
+
+#include "ColibriGui/ColibriSlider.h"
+
+#include "ColibriGui/ColibriManager.h"
+#include "ColibriGui/ColibriSkinManager.h"
+
+namespace Colibri
+{
+	Slider::Slider( ColibriManager *manager ) :
+		Widget( manager ),
+		IdObject( Ogre::Id::generateNewId<Progressbar>() ),
+		m_sliderValue( 0.0f )
+	{
+		memset( m_layers, 0, sizeof( m_layers ) );
+
+		m_clickable = true;
+		m_keyboardNavigable = true;
+	}
+	//-------------------------------------------------------------------------
+	void Slider::_initialize()
+	{
+		for( size_t i = 0u; i < 2u; ++i ){
+			m_layers[i] = m_manager->createWidget<Renderable>( this );
+			m_layers[i]->_initialize();
+		}
+
+		getSliderLine()->_setSkinPack( m_manager->getDefaultSkin( SkinWidgetTypes::SliderLine ) );
+		getSliderHandle()->_setSkinPack( m_manager->getDefaultSkin( SkinWidgetTypes::SliderHandle ) );
+
+		Widget::_initialize();
+
+
+		/*const Ogre::IdString skinPackName =
+			m_manager->getDefaultSkinPackName( SkinWidgetTypes::SliderLine );
+		const SkinManager *skinManager = m_manager->getSkinManager();
+
+		const SkinPack *defaultSkinPack = skinManager->findSkinPack( skinPackName, LogSeverity::Fatal );
+
+		if( !defaultSkinPack )
+			return;*/
+	}
+	//-------------------------------------------------------------------------
+	void Slider::_destroy()
+	{
+		Widget::_destroy();
+
+		// m_layers[i] are children of us, so they will be destroyed by our super class
+		for( size_t i = 0u; i < 2u; ++i )
+			m_layers[i] = 0;
+	}
+	//-------------------------------------------------------------------------
+	Renderable *colibrigui_nullable Slider::getSliderLine()
+	{
+		return m_layers[0];
+	}
+	//-------------------------------------------------------------------------
+	Renderable *colibrigui_nullable Slider::getSliderHandle()
+	{
+		return m_layers[1];
+	}
+	//-------------------------------------------------------------------------
+	void Slider::setVisualsEnabled( bool bEnabled )
+	{
+		for( size_t i = 0u; i < 2u; ++i )
+			m_layers[i]->setVisualsEnabled( bEnabled );
+	}
+	//-------------------------------------------------------------------------
+	bool Slider::isVisualsEnabled() const { return m_layers[0]->isVisualsEnabled(); }
+	//-------------------------------------------------------------------------
+	void Slider::setState( States::States state, bool smartHighlight, bool broadcastEnable )
+	{
+		Widget::setState( state, smartHighlight, broadcastEnable );
+
+		// Widget::setState did not re-enable children we control. Do it manually
+		if( !broadcastEnable )
+		{
+			for( size_t i = 0u; i < 2u; ++i )
+			{
+				if( m_layers[i]->isDisabled() )
+					m_layers[i]->setState( state, smartHighlight, false );
+			}
+		}
+	}
+	//-------------------------------------------------------------------------
+	void Slider::updateSlider()
+	{
+
+		if( !m_layers[0] )
+			return;  //_initialize hasn't been called yet
+
+		const Ogre::Vector2 frameSize = getSize();
+		static const float sliderLineHeight = 5.0f;
+
+		// Slider line
+		//const Ogre::Vector2 framePosition = getLocalTopLeft();
+		const Ogre::Vector2 framePosition = Ogre::Vector2::ZERO;
+		const float lineY = framePosition.y + (frameSize.y / 2.0f) - (sliderLineHeight / 2.0f);
+		m_layers[0]->setTopLeft( Ogre::Vector2(framePosition.x, lineY) );
+
+		// The width is used to its full, but the height is always a constant.
+		m_layers[0]->setSize( Ogre::Vector2(frameSize.x, sliderLineHeight) );
+
+
+		// Slider handle
+		const float handleSize = frameSize.y / 2.0f;
+		m_layers[1]->setSize( Ogre::Vector2(handleSize, handleSize) );
+
+
+		m_layers[1]->setTopLeft( Ogre::Vector2(framePosition.x + frameSize.x * m_sliderValue, sliderLineHeight) );
+
+		for( size_t i = 0u; i < 2u; ++i )
+			m_layers[i]->updateDerivedTransformFromParent( false );
+	}
+	//-------------------------------------------------------------------------
+	void Slider::setTransformDirty( uint32_t dirtyReason )
+	{
+		// Only update if our size is directly being changed, not our parent's
+		if( ( dirtyReason & ( TransformDirtyParentCaller | TransformDirtyScale ) ) ==
+			TransformDirtyScale )
+		{
+			updateSlider();
+		}
+
+		Widget::setTransformDirty( dirtyReason );
+	}
+	//-------------------------------------------------------------------------
+	void Slider::setValue( float value )
+	{
+		if( value < 0.0f ) value = 0.0f;
+		else if( value > 1.0f ) value = 1.0f;
+
+		m_sliderValue = value;
+
+		updateSlider();
+	}
+}  // namespace Colibri

--- a/src/ColibriGui/ColibriSlider.cpp
+++ b/src/ColibriGui/ColibriSlider.cpp
@@ -181,5 +181,7 @@ namespace Colibri
 		m_sliderValue = value;
 
 		updateSlider();
+
+		callActionListeners( Action::ValueChanged );
 	}
 }  // namespace Colibri

--- a/src/ColibriGui/ColibriSlider.cpp
+++ b/src/ColibriGui/ColibriSlider.cpp
@@ -6,15 +6,14 @@
 
 namespace Colibri
 {
-	//TODO global for now
-	static const float handleSize = 30.0f;
 
 	Slider::Slider( ColibriManager *manager ) :
 		Widget( manager ),
 		IdObject( Ogre::Id::generateNewId<Progressbar>() ),
 		m_sliderValue( 0.0f ),
 		m_directionChangeAmount( 0.1f ),
-		m_cursorOffset( 0.0f )
+		m_cursorOffset( 0.0f ),
+		m_handleSize( 10.0f )
 	{
 		memset( m_layers, 0, sizeof( m_layers ) );
 
@@ -105,23 +104,25 @@ namespace Colibri
 		const Ogre::Vector2 frameSize = getSize();
 		static const float sliderLineHeight = 5.0f;
 
+		m_handleSize = frameSize.y * 0.8f;
+
 		// Slider line
 		//const Ogre::Vector2 framePosition = getLocalTopLeft();
 		const Ogre::Vector2 framePosition = Ogre::Vector2::ZERO;
 		const float lineY = framePosition.y + (frameSize.y / 2.0f) - (sliderLineHeight / 2.0f);
 
 		// Half a handle is added to the line on each side as padding.
-		m_layers[0]->setTopLeft( Ogre::Vector2(framePosition.x + handleSize / 2.0f, lineY) );
+		m_layers[0]->setTopLeft( Ogre::Vector2(framePosition.x + m_handleSize / 2.0f, lineY) );
 
 		// Other than the padding, the width is used to its full, but the height is always a constant.
-		const float reducedLineWidth = frameSize.x - handleSize;
+		const float reducedLineWidth = frameSize.x - m_handleSize;
 		m_layers[0]->setSize( Ogre::Vector2(reducedLineWidth, sliderLineHeight) );
 
 
 		// Slider handle
-		m_layers[1]->setSize( Ogre::Vector2(handleSize, handleSize) );
+		m_layers[1]->setSize( Ogre::Vector2(m_handleSize, m_handleSize) );
 
-		m_layers[1]->setTopLeft( Ogre::Vector2(framePosition.x + (reducedLineWidth * m_sliderValue), lineY - handleSize / 2.0f) );
+		m_layers[1]->setTopLeft( Ogre::Vector2(framePosition.x + (reducedLineWidth * m_sliderValue), lineY - m_handleSize / 2.0f) );
 
 		for( size_t i = 0u; i < 2u; ++i )
 			m_layers[i]->updateDerivedTransformFromParent( false );

--- a/src/ColibriGui/ColibriWidget.cpp
+++ b/src/ColibriGui/ColibriWidget.cpp
@@ -520,6 +520,10 @@ namespace Colibri
 		return retVal;
 	}
 	//-------------------------------------------------------------------------
+	void Widget::notifyCursorMoved( const Ogre::Vector2& posNDC )
+	{
+	}
+	//-------------------------------------------------------------------------
 	void Widget::broadcastNewVao( Ogre::VertexArrayObject *vao, Ogre::VertexArrayObject *textVao )
 	{
 		WidgetVec::const_iterator itor = m_children.begin();

--- a/src/ColibriGui/ColibriWidget.cpp
+++ b/src/ColibriGui/ColibriWidget.cpp
@@ -27,6 +27,7 @@ namespace Colibri
 		m_keyboardNavigable( false ),
 		m_childrenClickable( false ),
 		m_pressable( true ),
+		m_consumesScroll( false ),
 		m_culled( false ),
 		m_breadthFirst( false ),
 		m_userId( 0 ),

--- a/src/ColibriGuiGameState.cpp
+++ b/src/ColibriGuiGameState.cpp
@@ -53,6 +53,7 @@ namespace Demo
 	Colibri::Progressbar *progressBar0 = 0;
 	Colibri::Progressbar *progressBar1 = 0;
 	Colibri::Slider *slider1 = 0;
+	Colibri::Label *sliderLabel = 0;
 
     ColibriGuiGameState::ColibriGuiGameState( const Ogre::String &helpDescription ) :
 		TutorialGameState( helpDescription )
@@ -163,8 +164,13 @@ namespace Demo
 		layout->addCell( progressBar1 );
 
 		slider1 = colibriManager->createWidget<Colibri::Slider>( mainWindow );
-		slider1->m_minSize = Ogre::Vector2( 350, 64 );
+		slider1->m_minSize = Ogre::Vector2( 350, 32 );
 		layout->addCell( slider1 );
+
+		sliderLabel = colibriManager->createWidget<Colibri::Label>( mainWindow );
+		sliderLabel->sizeToFit();
+		sliderLabel->m_minSize = Ogre::Vector2( 350, 32 );
+		layout->addCell( sliderLabel );
 
 		{
 			const Colibri::LayoutCellVec &cells = layout->getCells();
@@ -341,10 +347,13 @@ namespace Demo
 		button->setOrientation( rotMat );
 		angle += timeSinceLast;*/
 
-		// static float count = 0.0f;
-		// count += 0.01;
-		// float value = 0.5f + 0.5f * sin(count);
-		// slider1->setValue( value );
+		static float prevValue = -1.0f;
+		float currentValue = slider1->getValue();
+		if( prevValue != currentValue )
+		{
+			sliderLabel->setText( std::to_string(currentValue) );
+			prevValue = currentValue;
+		}
 
         TutorialGameState::update( timeSinceLast );
     }

--- a/src/ColibriGuiGameState.cpp
+++ b/src/ColibriGuiGameState.cpp
@@ -341,10 +341,10 @@ namespace Demo
 		button->setOrientation( rotMat );
 		angle += timeSinceLast;*/
 
-		static float count = 0.0f;
-		count += 0.01;
-		float value = 0.5f + 0.5f * sin(count);
-		slider1->setValue( value );
+		// static float count = 0.0f;
+		// count += 0.01;
+		// float value = 0.5f + 0.5f * sin(count);
+		// slider1->setValue( value );
 
         TutorialGameState::update( timeSinceLast );
     }

--- a/src/ColibriGuiGameState.cpp
+++ b/src/ColibriGuiGameState.cpp
@@ -32,6 +32,7 @@
 #include "ColibriGui/ColibriLabel.h"
 #include "ColibriGui/ColibriSpinner.h"
 #include "ColibriGui/ColibriProgressbar.h"
+#include "ColibriGui/ColibriSlider.h"
 
 #include "ColibriGui/Layouts/ColibriLayoutLine.h"
 #include "ColibriGui/Layouts/ColibriLayoutMultiline.h"
@@ -51,6 +52,7 @@ namespace Demo
 	Colibri::Editbox *editbox0 = 0;
 	Colibri::Progressbar *progressBar0 = 0;
 	Colibri::Progressbar *progressBar1 = 0;
+	Colibri::Slider *slider1 = 0;
 
     ColibriGuiGameState::ColibriGuiGameState( const Ogre::String &helpDescription ) :
 		TutorialGameState( helpDescription )
@@ -159,6 +161,10 @@ namespace Demo
 		progressBar1->setVertical( true );
 		progressBar1->getProgressLayer()->setColour( true, Ogre::ColourValue( 0.0f, 0.7f, 0.2f ) );
 		layout->addCell( progressBar1 );
+
+		slider1 = colibriManager->createWidget<Colibri::Slider>( mainWindow );
+		slider1->m_minSize = Ogre::Vector2( 350, 64 );
+		layout->addCell( slider1 );
 
 		{
 			const Colibri::LayoutCellVec &cells = layout->getCells();
@@ -334,6 +340,11 @@ namespace Demo
 		rotMat.FromEulerAnglesXYZ( Ogre::Degree( 0 ), Ogre::Radian( 0 ), Ogre::Radian( angle ) );
 		button->setOrientation( rotMat );
 		angle += timeSinceLast;*/
+
+		static float count = 0.0f;
+		count += 0.01;
+		float value = 0.5f + 0.5f * sin(count);
+		slider1->setValue( value );
 
         TutorialGameState::update( timeSinceLast );
     }


### PR DESCRIPTION
![footage](https://user-images.githubusercontent.com/4259278/81487422-7705d300-9254-11ea-8e09-b938cd1bcee2.gif)

This is an implementation of the common slider widget. It allows the user to slide the slider to input a value, which is specified between 0 and 1. It allows mouse picking as well as keyboard left and right input.

Implementation notes:
- I added a new method to widgets, notifyCursorMoved. This is called by ColibriManager::updateWidgetsFocusedByCursor. This is how I get the position of the mouse in the widget. It's meant to be overridden by widgets that care about it. The default is just an empty function.
- I added a new attribute to widgets, m_consumesScroll. If this is true, no mouse scroll can occur as the mouse is over this widget. For instance, buttons or the like don't care if the user does a mouse click and move scroll while hovered over them. However for a slider widget, which relies on mouse click and movement, this is a problem. If a widget with this enabled is clicked and dragged, the scroll will be 'consumed', meaning it won't happen at all. 
- Right now the slider is just made up of two button skins. I think it looks good, but I'm not an artist so didn't want to attempt anything more exciting. 

Thanks!