### PR TITLE
Logged the rapidjson error reason during loadSkins.

### DIFF
--- a/src/ColibriGui/ColibriSkinManager.cpp
+++ b/src/ColibriGui/ColibriSkinManager.cpp
@@ -6,6 +6,7 @@
 
 #include "OgreLwString.h"
 #include "rapidjson/document.h"
+#include <rapidjson/error/en.h>
 
 #include <fstream>
 
@@ -626,6 +627,10 @@ namespace Colibri
 		{
 			errorMsg.clear();
 			errorMsg.a( "[SkinManager::loadSkins]: Invalid JSON string in file ", filename );
+			log->log( errorMsg.c_str(), LogSeverity::Error );
+
+			errorMsg.clear();
+			errorMsg.a( "[SkinManager::loadSkins]: ", rapidjson::GetParseError_En(d.GetParseError()) );
 			log->log( errorMsg.c_str(), LogSeverity::Error );
 			return;
 		}


### PR DESCRIPTION
This is useful when making custom skins, as it can help provide more information as to what went wrong.