### PR TITLE
Widget Z Ordering

### DIFF
--- a/include/ColibriGui/ColibriManager.h
+++ b/include/ColibriGui/ColibriManager.h
@@ -88,10 +88,11 @@ namespace Colibri
 		bool m_windowNavigationDirty;
 		bool m_numGlyphsDirty;
 
-		/// Is any window dirty
-		bool m_zOrderWindowDirty;
-		/// Is a window stored in this list immediately dirty.
+		/// Is any widget dirty
+		bool m_zOrderWidgetDirty;
+		/// Is one of the windows stored by this manager immediately dirty.
 		bool m_zOrderHasDirtyChildren;
+		void reorderWindowVec( bool windowInListDirty, WindowVec& windows );
 
 		Ogre::Root					* colibrigui_nullable m_root;
 		Ogre::VaoManager			* colibrigui_nullable m_vaoManager;

--- a/include/ColibriGui/ColibriManager.h
+++ b/include/ColibriGui/ColibriManager.h
@@ -88,6 +88,11 @@ namespace Colibri
 		bool m_windowNavigationDirty;
 		bool m_numGlyphsDirty;
 
+		/// Is any window dirty
+		bool m_zOrderWindowDirty;
+		/// Is a window stored in this list immediately dirty.
+		bool m_zOrderHasDirtyChildren;
+
 		Ogre::Root					* colibrigui_nullable m_root;
 		Ogre::VaoManager			* colibrigui_nullable m_vaoManager;
 		Ogre::ObjectMemoryManager	* colibrigui_nullable m_objectMemoryManager;
@@ -169,6 +174,8 @@ namespace Colibri
 		void autosetNavigation( const std::vector<T> &container, size_t start, size_t numWidgets );
 
 		void autosetNavigation( Window *window );
+
+		void updateZOrderDirty();
 
 		/// Ensure its immediate parent window has the given widget within its visible bounds.
 		void scrollToWidget( Widget *widget );
@@ -356,6 +363,10 @@ namespace Colibri
 		void autosetNavigation();
 
 		void _setWindowNavigationDirty();
+		/// Notify the manager that a window has its z order dirty.
+		/// @param windowInListDirty should be true if a window this manager directly
+		/// owns is dirty.
+		void _setZOrderWindowDirty( bool windowInListDirty );
 		void _addDirtyLabel( Label *label );
 
 		void update( float timeSinceLast );

--- a/include/ColibriGui/ColibriWidget.h
+++ b/include/ColibriGui/ColibriWidget.h
@@ -315,10 +315,10 @@ namespace Colibri
 		void callActionListeners( Action::Action action );
 
 		/// Set order in which this widget should be drawn.
-		/// Windows with a higher z order value will be drawn last,
-		/// and therefore above windows with a lower value.
-		/// Windows with the same z value will be drawn according to their creation order.
-		/// This function triggers a re-order of the windows list.
+		/// Widgets with a higher z order value will be drawn last,
+		/// and therefore above widgets with a lower value.
+		/// Widgets with the same z value will be drawn according to their creation order.
+		/// This function triggers a re-order of the widgets and windows list.
 		void setZOrder( uint8_t z );
 		uint8_t getZOrder() const { return static_cast<uint8_t>( m_zOrder ); }
 		/// Get the internal z order of the widget, where the last 8 bits are used for

--- a/include/ColibriGui/ColibriWindow.h
+++ b/include/ColibriGui/ColibriWindow.h
@@ -34,14 +34,27 @@ namespace Colibri
 		/// When true, all of our immediate children (widgets or windows)
 		/// are not dirty, but one of our children's child is.
 		bool		m_childrenNavigationDirty;
+		/// When true the current window needs to have its window list reordered.
+		/// A window can still have dirty child windows but not need its list reordered.
+		bool		m_zOrderWindowDirty;
+		/// When true this window contains a child in its window list which is dirty.
+		bool		m_zOrderHasDirtyChildren;
+
+		uint8_t		m_zOrder;
 
 		WindowVec m_childWindows;
 
 		void notifyChildWindowIsDirty();
+		void notifyZOrderChildWindowIsDirty( bool firstCall );
 
 		Window* getParentAsWindow() const;
 
 		virtual size_t notifyParentChildIsDestroyed( Widget *childWidgetBeingRemoved ) colibri_override;
+
+		/// Perform the re-ordering of windows based on their z-order.
+		/// This will also recursively search for other dirty windows in the list.
+		/// This function is static so ColibriManager can use it with its WindowVec as well.
+		static void reorderWindowVec( bool windowInListDirty, WindowVec& win, WidgetVec* widgetVec = 0 );
 
 	public:
 		Window( ColibriManager *manager );
@@ -111,6 +124,18 @@ namespace Colibri
 		void detachChild( Window *window );
 		/// Detaches from current parent. Does nothing if already parentless
 		void detachFromParent();
+
+		/// Set order in which this window should be drawn.
+		/// Windows with a higher z order value will be drawn last,
+		/// and therefore above windows with a lower value.
+		/// Windows with the same value are drawn in an undefined order.
+		/// This function triggers a re-order of the windows list.
+		void setZOrder( uint8_t z );
+		uint8_t getZOrder() const { return m_zOrder; }
+		bool getZOrderWindowDirty() const { return m_zOrderWindowDirty; }
+		bool getZOrderHasDirtyChildren() const { return m_zOrderHasDirtyChildren; }
+
+		void updateZOrderDirty();
 
 		/// Makes this widget the default widget (i.e. which widget the cursor
 		/// defaults to when the window is created)

--- a/include/ColibriGui/ColibriWindow.h
+++ b/include/ColibriGui/ColibriWindow.h
@@ -34,27 +34,16 @@ namespace Colibri
 		/// When true, all of our immediate children (widgets or windows)
 		/// are not dirty, but one of our children's child is.
 		bool		m_childrenNavigationDirty;
-		/// When true the current window needs to have its window list reordered.
-		/// A window can still have dirty child windows but not need its list reordered.
-		bool		m_zOrderWindowDirty;
-		/// When true this window contains a child in its window list which is dirty.
-		bool		m_zOrderHasDirtyChildren;
-
-		uint8_t		m_zOrder;
 
 		WindowVec m_childWindows;
 
 		void notifyChildWindowIsDirty();
-		void notifyZOrderChildWindowIsDirty( bool firstCall );
+		/// Reorder both the widget vec and the m_childWindows vec.
+		virtual void reorderWidgetVec( bool widgetInListDirty, WidgetVec& widgets );
 
 		Window* getParentAsWindow() const;
 
 		virtual size_t notifyParentChildIsDestroyed( Widget *childWidgetBeingRemoved ) colibri_override;
-
-		/// Perform the re-ordering of windows based on their z-order.
-		/// This will also recursively search for other dirty windows in the list.
-		/// This function is static so ColibriManager can use it with its WindowVec as well.
-		static void reorderWindowVec( bool windowInListDirty, WindowVec& win, WidgetVec* widgetVec = 0 );
 
 	public:
 		Window( ColibriManager *manager );
@@ -124,18 +113,6 @@ namespace Colibri
 		void detachChild( Window *window );
 		/// Detaches from current parent. Does nothing if already parentless
 		void detachFromParent();
-
-		/// Set order in which this window should be drawn.
-		/// Windows with a higher z order value will be drawn last,
-		/// and therefore above windows with a lower value.
-		/// Windows with the same value are drawn in an undefined order.
-		/// This function triggers a re-order of the windows list.
-		void setZOrder( uint8_t z );
-		uint8_t getZOrder() const { return m_zOrder; }
-		bool getZOrderWindowDirty() const { return m_zOrderWindowDirty; }
-		bool getZOrderHasDirtyChildren() const { return m_zOrderHasDirtyChildren; }
-
-		void updateZOrderDirty();
 
 		/// Makes this widget the default widget (i.e. which widget the cursor
 		/// defaults to when the window is created)

--- a/src/ColibriGui/ColibriManager.cpp
+++ b/src/ColibriGui/ColibriManager.cpp
@@ -1167,7 +1167,7 @@ namespace Colibri
 	void ColibriManager::_setZOrderWindowDirty( bool windowInListDirty )
 	{
 		m_zOrderWidgetDirty = true;
-		m_zOrderHasDirtyChildren = windowInListDirty;
+		m_zOrderHasDirtyChildren |= windowInListDirty;
 	}
 	//-------------------------------------------------------------------------
 	void ColibriManager::_addDirtyLabel( Label *label )

--- a/src/ColibriGui/ColibriManager.cpp
+++ b/src/ColibriGui/ColibriManager.cpp
@@ -44,6 +44,7 @@ namespace Colibri
 		m_colibriListener( &DefaultColibriListener ),
 		m_swapRTLControls( false ),
 		m_windowNavigationDirty( false ),
+		m_zOrderWindowDirty( false ),
 		m_numGlyphsDirty( false ),
 		m_root( 0 ),
 		m_vaoManager( 0 ),
@@ -1122,9 +1123,26 @@ namespace Colibri
 		}
 	}
 	//-------------------------------------------------------------------------
+	void ColibriManager::updateZOrderDirty()
+	{
+		if( m_zOrderWindowDirty )
+		{
+			Window::reorderWindowVec( m_zOrderHasDirtyChildren, m_windows );
+
+			m_zOrderWindowDirty = false;
+		}
+		m_zOrderHasDirtyChildren = false;
+	}
+	//-------------------------------------------------------------------------
 	void ColibriManager::_setWindowNavigationDirty()
 	{
 		m_windowNavigationDirty = true;
+	}
+	//-------------------------------------------------------------------------
+	void ColibriManager::_setZOrderWindowDirty( bool windowInListDirty )
+	{
+		m_zOrderWindowDirty = true;
+		m_zOrderHasDirtyChildren = windowInListDirty;
 	}
 	//-------------------------------------------------------------------------
 	void ColibriManager::_addDirtyLabel( Label *label )
@@ -1225,6 +1243,11 @@ namespace Colibri
 		}
 
 		bool cursorFocusDirty = false;
+
+		if( m_zOrderWindowDirty )
+		{
+			updateZOrderDirty();
+		}
 
 		WindowVec::const_iterator itor = m_windows.begin();
 		WindowVec::const_iterator end  = m_windows.end();

--- a/src/ColibriGui/ColibriManager.cpp
+++ b/src/ColibriGui/ColibriManager.cpp
@@ -45,6 +45,7 @@ namespace Colibri
 		m_swapRTLControls( false ),
 		m_windowNavigationDirty( false ),
 		m_zOrderWidgetDirty( false ),
+		m_zOrderHasDirtyChildren( false ),
 		m_numGlyphsDirty( false ),
 		m_root( 0 ),
 		m_vaoManager( 0 ),

--- a/src/ColibriGui/ColibriManager.cpp
+++ b/src/ColibriGui/ColibriManager.cpp
@@ -1136,7 +1136,7 @@ namespace Colibri
 	//-------------------------------------------------------------------------
 	bool compareZOrder( const Window* w1, const Window* w2 )
 	{
-		return w1->getZOrder() < w2->getZOrder();
+		return w1->_getZOrderInternal() < w2->_getZOrderInternal();
 	}
 	//-------------------------------------------------------------------------
 	void ColibriManager::reorderWindowVec( bool windowInListDirty, WindowVec& windows )

--- a/src/ColibriGui/ColibriWidget.cpp
+++ b/src/ColibriGui/ColibriWidget.cpp
@@ -44,7 +44,10 @@ namespace Colibri
 		m_clipBorderTL( Ogre::Vector2::ZERO ),
 		m_clipBorderBR( Ogre::Vector2::ZERO ),
 		m_accumMinClipTL( -1.0f ),
-		m_accumMaxClipBR( 1.0f )
+		m_accumMaxClipBR( 1.0f ),
+		m_zOrderDirty( false ),
+		m_zOrderHasDirtyChildren( false ),
+		m_zOrder( 0 )
 #if COLIBRIGUI_DEBUG >= COLIBRIGUI_DEBUG_MEDIUM
 		,
 		m_transformOutOfDate( false ),
@@ -826,6 +829,61 @@ namespace Colibri
 		m_position = topLeft;
 		m_size = size;
 		setTransformDirty( TransformDirtyPosition | TransformDirtyScale );
+	}
+	//-------------------------------------------------------------------------
+	void Widget::setZOrder( uint8_t z )
+	{
+		if( m_parent )
+		{
+			getParent()->m_zOrderDirty = true;
+		}
+		m_zOrder = z;
+		notifyZOrderChildWindowIsDirty( true );
+		//The above function sets this to true in the case of recursive calls up the tree.
+		//However from here we know no children should be set as dirty, so set it back to false.
+		m_zOrderHasDirtyChildren = false;
+	}
+	//-------------------------------------------------------------------------
+	void Widget::notifyZOrderChildWindowIsDirty( bool firstCall )
+	{
+		m_zOrderHasDirtyChildren = true;
+
+		if( m_parent )
+		{
+			Widget *parentWindow = getParent();
+			parentWindow->notifyZOrderChildWindowIsDirty( false );
+		}
+		else
+		{
+			m_manager->_setZOrderWindowDirty( firstCall );
+		}
+	}
+	//-------------------------------------------------------------------------
+	void Widget::reorderWidgetVec( bool widgetInListDirty, WidgetVec& widgets )
+	{
+		if( widgetInListDirty )
+		{
+			std::stable_sort( widgets.begin(), widgets.end(), _compareWidgetZOrder );
+		}
+
+		WidgetVec::iterator itor = widgets.begin();
+		WidgetVec::iterator end  = widgets.end();
+
+		while( itor != end )
+		{
+			if( (*itor)->getZOrderHasDirtyChildren() )
+			{
+				(*itor)->updateZOrderDirty();
+			}
+			++itor;
+		}
+	}
+	//-------------------------------------------------------------------------
+	void Widget::updateZOrderDirty()
+	{
+		reorderWidgetVec( getZOrderDirty(), m_children );
+		m_zOrderDirty = false;
+		m_zOrderHasDirtyChildren = false;
 	}
 	//-------------------------------------------------------------------------
 	void Widget::setTopLeft( const Ogre::Vector2 &topLeft )

--- a/src/ColibriGui/ColibriWindow.cpp
+++ b/src/ColibriGui/ColibriWindow.cpp
@@ -17,10 +17,7 @@ namespace Colibri
 		m_defaultChildWidget( 0 ),
 		m_widgetNavigationDirty( false ),
 		m_windowNavigationDirty( false ),
-		m_childrenNavigationDirty( false ),
-		m_zOrderWindowDirty( false ),
-		m_zOrderHasDirtyChildren( false ),
-		m_zOrder( 0 )
+		m_childrenNavigationDirty( false )
 	{
 		m_childrenClickable = true;
 	}
@@ -228,75 +225,14 @@ namespace Colibri
 		}
 	}
 	//-------------------------------------------------------------------------
-	void Window::setZOrder( uint8_t z )
+	void Window::reorderWidgetVec( bool widgetInListDirty, WidgetVec& widgets )
 	{
-		if( m_parent )
+		Widget::reorderWidgetVec( widgetInListDirty, widgets );
+		//Sort the windows as well as the widgets to keep them in the same order.
+		if( widgetInListDirty )
 		{
-			getParentAsWindow()->m_zOrderWindowDirty = true;
+			std::stable_sort( m_childWindows.begin(), m_childWindows.end(), _compareWidgetZOrder );
 		}
-		m_zOrder = z;
-		notifyZOrderChildWindowIsDirty( true );
-		//The above function sets this to true in the case of recursive calls up the tree.
-		//However from here we know no children should be set as dirty, so set it back to false.
-		m_zOrderHasDirtyChildren = false;
-	}
-	//-------------------------------------------------------------------------
-	void Window::notifyZOrderChildWindowIsDirty( bool firstCall )
-	{
-		m_zOrderHasDirtyChildren = true;
-
-		if( m_parent )
-		{
-			Window *parentWindow = getParentAsWindow();
-			parentWindow->notifyZOrderChildWindowIsDirty( false );
-		}
-		else
-		{
-			m_manager->_setZOrderWindowDirty( firstCall );
-		}
-	}
-	//-------------------------------------------------------------------------
-	bool compareZOrder( const Window* w1, const Window* w2 )
-	{
-		return w1->getZOrder() < w2->getZOrder();
-	}
-	//-------------------------------------------------------------------------
-	bool compareWidgetZOrder( const Widget* w1, const Widget* w2 )
-	{
-		if( !w1->isWindow() || !w2->isWindow() ) return false;
-		return dynamic_cast<const Window*>(w1)->getZOrder() < dynamic_cast<const Window*>(w2)->getZOrder();
-	}
-	//-------------------------------------------------------------------------
-	void Window::reorderWindowVec( bool windowInListDirty, WindowVec& win, WidgetVec* widgetVec )
-	{
-		if( windowInListDirty )
-		{
-			std::stable_sort( win.begin(), win.end(), compareZOrder );
-			if( widgetVec )
-			{
-				std::stable_sort( widgetVec->begin(), widgetVec->end(), compareWidgetZOrder );
-			}
-		}
-
-		WindowVec::iterator itor = win.begin();
-		WindowVec::iterator end  = win.end();
-
-		while( itor != end )
-		{
-			if( (*itor)->getZOrderHasDirtyChildren() )
-			{
-				(*itor)->updateZOrderDirty();
-			}
-			++itor;
-		}
-
-	}
-	//-------------------------------------------------------------------------
-	void Window::updateZOrderDirty()
-	{
-		Window::reorderWindowVec( getZOrderWindowDirty(), m_childWindows, &m_children );
-		m_zOrderWindowDirty = false;
-		m_zOrderHasDirtyChildren = false;
 	}
 	//-------------------------------------------------------------------------
 	void Window::setWidgetNavigationDirty()

--- a/src/ColibriGuiGameState.cpp
+++ b/src/ColibriGuiGameState.cpp
@@ -63,25 +63,29 @@ namespace Demo
 	Colibri::Button *orderButtonFront = 0;
 	Colibri::Window *innerOverlapWindow1 = 0;
 	Colibri::Window *innerOverlapWindow2 = 0;
+	Colibri::Button* innerOverlapButton1 = 0;
+	Colibri::Button* innerOverlapButton2 = 0;
 	Colibri::Button *innerToggleOrder = 0;
 
 	class DemoWidgetListener : public Colibri::WidgetActionListener
 	{
+	public:
+		virtual ~DemoWidgetListener() {}
 		virtual void notifyWidgetAction( Colibri::Widget *widget, Colibri::Action::Action action )
 		{
 			if( action == Colibri::Action::Action::PrimaryActionPerform )
 			{
 				if( widget == orderButtonBack )
-					overlapWindow1->setZOrder(3);
+					overlapWindow1->setZOrder( 3 );
 				else if( widget == orderButtonFront )
-					overlapWindow1->setZOrder(5);
+					overlapWindow1->setZOrder( 5 );
 				else if( widget == innerToggleOrder )
 				{
 					uint8_t oldOrder = innerOverlapWindow1->getZOrder();
-					innerOverlapWindow1->setZOrder(innerOverlapWindow2->getZOrder());
-					innerOverlapWindow2->setZOrder(oldOrder);
-					innerOverlapWindow2->setTopLeft(innerOverlapWindow2->getLocalTopLeft());
-					innerOverlapWindow1->setTopLeft(innerOverlapWindow1->getLocalTopLeft());
+					innerOverlapWindow1->setZOrder( innerOverlapWindow2->getZOrder() );
+					innerOverlapButton1->setZOrder( innerOverlapWindow2->getZOrder() );
+					innerOverlapWindow2->setZOrder( oldOrder );
+					innerOverlapButton2->setZOrder( oldOrder );
 				}
 			}
 		}
@@ -113,7 +117,7 @@ namespace Demo
 		//mainWindow->setVisualsEnabled( false );
 		vertWindow = colibriManager->createWindow( 0 );
 
-		Ogre::Hlms *hlms = mGraphicsSystem->getRoot()->getHlmsManager()->getHlms( Ogre::HLMS_UNLIT );
+		//Ogre::Hlms *hlms = mGraphicsSystem->getRoot()->getHlmsManager()->getHlms( Ogre::HLMS_UNLIT );
 		//mainWindow->setDatablock( hlms->getDefaultDatablock() );
 
 		mainWindow->setTransform( Ogre::Vector2( 0, 0 ), Ogre::Vector2( 450, 0 ) );
@@ -269,17 +273,27 @@ namespace Demo
 
 		{
 			innerOverlapWindow1 = colibriManager->createWindow( overlapWindow2 );
-			innerOverlapWindow1->setTransform(Ogre::Vector2(10, 10), Ogre::Vector2(100, 100));
+			innerOverlapWindow1->setTransform( Ogre::Vector2(10, 10), Ogre::Vector2(100, 100) );
 			innerOverlapWindow1->setZOrder(1);
+			innerOverlapWindow2 = colibriManager->createWindow( overlapWindow2 );
+			innerOverlapWindow2->setTransform( Ogre::Vector2(20, 20), Ogre::Vector2(100, 100) );
+			innerOverlapWindow2->setZOrder(4);
+
+			innerOverlapButton1 = colibriManager->createWidget<Colibri::Button>( overlapWindow2 );
+			innerOverlapButton1->getLabel()->setText( "First" );
+			innerOverlapButton1->setTransform( Ogre::Vector2(150, 10), Ogre::Vector2(100, 100) );
+			innerOverlapButton1->setZOrder(1);
+			innerOverlapButton2 = colibriManager->createWidget<Colibri::Button>( overlapWindow2 );
+			innerOverlapButton2->setTransform( Ogre::Vector2(160, 20), Ogre::Vector2(100, 100) );
+			innerOverlapButton2->setZOrder(2);
+			innerOverlapButton2->getLabel()->setText( "Second" );
+
 			innerToggleOrder = colibriManager->createWidget<Colibri::Button>( overlapWindow2 );
 			innerToggleOrder->m_minSize = Ogre::Vector2( 350, 64 );
 			innerToggleOrder->getLabel()->setText( "Switch order" );
-			innerToggleOrder->setTopLeft(Ogre::Vector2(0, 120));
+			innerToggleOrder->setTopLeft( Ogre::Vector2(0, 120) );
 			innerToggleOrder->addActionListener(demoActionListener);
 			innerToggleOrder->sizeToFit();
-			innerOverlapWindow2 = colibriManager->createWindow( overlapWindow2 );
-			innerOverlapWindow2->setTransform(Ogre::Vector2(20, 20), Ogre::Vector2(100, 100));
-			innerOverlapWindow2->setZOrder(4);
 		}
 
 #if 0


### PR DESCRIPTION
![Peek 2020-12-20 14-21](https://user-images.githubusercontent.com/4259278/102715621-a4c4f700-42ce-11eb-88a9-2389fb03d699.gif)

- Adds a function, setZOrder to all widgets which can be used to manually specify the draw order.
- Included an example in the demo app.
  - This demonstrates reordering windows owned by the manager as well as child windows of another window. 
  - Some generic button widgets are also demonstrated.
- The user is allowed to specify an 8 bit value of layers, although internally 16 bits are used to ensure windows and renderables are placed at the end of the widgets list. I went with 8 bits because I feel it's plenty and will help save memory if all widgets are including it.
- Widgets are reordered based on a dirty flag so the sorting only happens when needed.

Thanks for your input on this and for answering my questions!