### PR TITLE
Added flexibility options.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@
 cmake_minimum_required( VERSION 3.3 )
 project( ColibriGui )
 
+set( COLIBRIGUI_FLEXIBILITY_LEVEL 0 CACHE STRING "Higher flexibility levels convert some functions to virtual in a tradeoff of flexibility for performance" )
+
 if( ${CMAKE_VERSION} VERSION_GREATER 3.9 AND NOT COLIBRIGUI_LIB_ONLY )
 	# We need to do this first, as OGRE.cmake will add another FindDoxygen.cmake file
 	# which is older than the system-provided one.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,10 @@ if( MSVC90 )
 	include_directories( "./Dependencies/MSVC_Fix" )
 endif()
 
+if( COLIBRIGUI_FLEXIBILITY_LEVEL GREATER 0 )
+	add_compile_definitions(COLIBRI_FLEXIBILITY_LEVEL=${COLIBRIGUI_FLEXIBILITY_LEVEL})
+endif()
+
 if( NOT COLIBRIGUI_LIB_ONLY )
 	#add_recursive( ./src SOURCES )
 	#add_recursive( ./include HEADERS )

--- a/include/ColibriGui/ColibriGuiPrerequisites.h
+++ b/include/ColibriGui/ColibriGuiPrerequisites.h
@@ -31,7 +31,7 @@
 	#define colibri_final
 #endif
 
-#if COLIBRI_FLEXIBILITY_LEVEL > 1
+#if defined( COLIBRI_FLEXIBILITY_LEVEL ) && COLIBRI_FLEXIBILITY_LEVEL > 1
 	#define colibri_virtual_l1 virtual
 #else
 	#define colibri_virtual_l1

--- a/include/ColibriGui/ColibriGuiPrerequisites.h
+++ b/include/ColibriGui/ColibriGuiPrerequisites.h
@@ -31,6 +31,12 @@
 	#define colibri_final
 #endif
 
+#if COLIBRI_FLEXIBILITY_LEVEL > 1
+	#define colibri_virtual_l1 virtual
+#else
+	#define colibri_virtual_l1
+#endif
+
 #include <stdint.h>
 #include <math.h>
 #include "math_round.h"

--- a/include/ColibriGui/ColibriLabel.h
+++ b/include/ColibriGui/ColibriLabel.h
@@ -1,6 +1,7 @@
 
 #pragma once
 
+#include "ColibriGui/ColibriGuiPrerequisites.h"
 #include "ColibriGui/ColibriRenderable.h"
 #include "ColibriGui/Text/ColibriShaper.h"
 
@@ -15,6 +16,7 @@ namespace Colibri
 	*/
 	class Label : public Renderable
 	{
+	protected:
 		struct Word
 		{
 			size_t offset;
@@ -71,7 +73,7 @@ namespace Colibri
 		@param bPlaceGlyphs
 			When true, we will also call placeGlyphs
 		*/
-		void updateGlyphs( States::States state, bool bPlaceGlyphs=true );
+		colibri_virtual_l1 void updateGlyphs( States::States state, bool bPlaceGlyphs=true );
 
 		/** Places the glyphs obtained from updateGlyphs at the correct position
 			(always assuming TextHorizAlignment::Left) considering word wrap
@@ -101,7 +103,7 @@ namespace Colibri
 		float findLineMaxHeight( ShapedGlyphVec::const_iterator start,
 								 States::States state ) const;
 
-		inline void addQuad( GlyphVertex * RESTRICT_ALIAS vertexBuffer,
+		colibri_virtual_l1 inline void addQuad( GlyphVertex * RESTRICT_ALIAS vertexBuffer,
 							 Ogre::Vector2 topLeft,
 							 Ogre::Vector2 bottomRight,
 							 uint16_t glyphWidth,
@@ -375,7 +377,7 @@ namespace Colibri
 											  RESTRICT_ALIAS textVertBuffer,
 											  const Ogre::Vector2 &parentPos,
 											  const Ogre::Vector2 &parentCurrentScrollPos,
-											  const Matrix2x3 &parentRot ) colibri_final;
+											  const Matrix2x3 &parentRot );
 
 		virtual void setTransformDirty( uint32_t dirtyReason ) colibri_final;
 

--- a/include/ColibriGui/ColibriManager.h
+++ b/include/ColibriGui/ColibriManager.h
@@ -407,6 +407,9 @@ namespace Colibri
 
 		void _setWidgetTransformsDirty();
 
+		/// If creating a custom label widget, this must be called on creation.
+		void _notifyLabelCreated( Label* label );
+
 		/** Notify the manager that a window has its z order dirty.
 		@param windowInListDirty
 			Should be true if a window this manager directly owns is dirty.

--- a/src/ColibriGui/ColibriManager.cpp
+++ b/src/ColibriGui/ColibriManager.cpp
@@ -747,9 +747,14 @@ namespace Colibri
 	Label * colibrigui_nonnull ColibriManager::createWidget<Label>( Widget * colibrigui_nonnull parent )
 	{
 		Label *retVal = _createWidget<Label>( parent );
-		m_labels.push_back( retVal );
-		++m_numLabels;
+		_notifyLabelCreated( retVal );
 		return retVal;
+	}
+	//-------------------------------------------------------------------------
+	void ColibriManager::_notifyLabelCreated( Label* label )
+	{
+		m_labels.push_back( label );
+		++m_numLabels;
 	}
 	//-------------------------------------------------------------------------
 	void ColibriManager::destroyWindow( Window *window )


### PR DESCRIPTION
As discussed in issue #39.

Added flexibility options to the build.

- Called it colibri_virtual_l1 because otherwise it conflicted with the ogre includes and defines.
- Removed final from _fillBuffersAndCommands. Can be a useful function if extending label.
- Separated out the logic in the manager to create a label, so it can be called as part of custom object creation.
- Made more of ColibriLabel protected by default.
    - While I only need a few bits for my work I think it might be useful to others in future as well.
- Flexibility options can be enabled in cmake like:
    - cmake -DCOLIBRIGUI_FLEXIBILITY_LEVEL=1 ..

Tested on Linux Mint 20.04 and Windows 10.

Thanks very much.