### PR TITLE
Fixed build with an Ogre dependency which does not include atmosphere.

### DIFF
--- a/CMake/Dependencies/OGRE.cmake
+++ b/CMake/Dependencies/OGRE.cmake
@@ -257,7 +257,7 @@ if( OGRE_STATIC )
 	endif()
 endif()
 
-if( OGRE_BUILD_COMPONENT_ATMOSPHERE )
+if( OGRE_BUILD_COMPONENT_ATMOSPHERE GREATER_EQUAL 0 )
 	message( STATUS "Detected Atmosphere Component. Linking against it." )
 	set( OGRE_LIBRARIES
 		${OGRE_LIBRARIES}


### PR DESCRIPTION
Trying to build with Ogre 2.2.7, the new atomosphere component is incorrectly included in the build which causes it to fail. Cmake string find returns -1 if the string is not found. Weirdly this means CMake executes the if statement. This test script
```
cmake_minimum_required( VERSION 3.3 )

project(test)

#Empty string so won't find it.
string( FIND "" "#define OGRE_BUILD_COMPONENT_ATMOSPHERE" OGRE_BUILD_COMPONENT_ATMOSPHERE )
message(${OGRE_BUILD_COMPONENT_ATMOSPHERE})
if (${OGRE_BUILD_COMPONENT_ATMOSPHERE})
	message("hello")
endif()
```

Gives the output
```
[edward@Charizard thing]$ cmake ..
-- The C compiler identification is GNU 11.2.0
-- The CXX compiler identification is GNU 11.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-1
hello
-- Configuring done
-- Generating done
-- Build files have been written to: /tmp/test/thing
```
So checking if the index is greater or equal than 0 fixes it.