### PR TITLE
Fixed build error on gcc compiler relating to warning flags.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,10 +123,13 @@ if( UNIX )
 	target_link_libraries( ${PROJECT_NAME} dl )
 endif()
 if( NOT MSVC )
-	target_compile_options( ${PROJECT_NAME} PRIVATE
-		-Wall -Winit-self -Wcast-qual -Wwrite-strings -Wextra
-		-Winconsistent-missing-destructor-override -Wcomma -Wsign-conversion -Wconversion
-		-Wno-unused-parameter -Wshadow -Wimplicit-fallthrough )
+	set( compileOptions -Wall -Winit-self -Wcast-qual -Wwrite-strings -Wextra
+		-Wsign-conversion -Wconversion
+		-Wno-unused-parameter -Wshadow -Wimplicit-fallthrough)
+	if( NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU" )
+		set( compileOptions ${compileOptions} -Winconsistent-missing-destructor-override -Wcomma )
+	endif()
+	target_compile_options( ${PROJECT_NAME} PRIVATE ${compileOptions})
 endif()
 
 if( APPLE )


### PR DESCRIPTION
Linux Mint 20.3
gcc (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0

Colibri fails to build for me relating to some invalid warning flags. From googling it seems these flags are available on clang, but not gcc. I've separated it out so they're removed if using gcc.

```
c++: error: unrecognized command line option ‘-Winconsistent-missing-destructor-override’
c++: error: unrecognized command line option ‘-Wcomma’; did you mean ‘-Wcomment’?
make[2]: *** [CMakeFiles/ColibriGui.dir/build.make:63: CMakeFiles/ColibriGui.dir/src/ColibriGui/ColibriAssert.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
c++: error: unrecognized command line option ‘-Winconsistent-missing-destructor-override’
c++: error: unrecognized command line option ‘-Wcomma’; did you mean ‘-Wcomment’?
make[2]: *** [CMakeFiles/ColibriGui.dir/build.make:89: CMakeFiles/ColibriGui.dir/src/ColibriGui/ColibriCheckbox.cpp.o] Error 1
c++: error: unrecognized command line option ‘-Winconsistent-missing-destructor-override’
c++: error: unrecognized command line option ‘-Wcomma’; did you mean ‘-Wcomment’?
make[2]: *** [CMakeFiles/ColibriGui.dir/build.make:76: CMakeFiles/ColibriGui.dir/src/ColibriGui/ColibriButton.cpp.o] Error 1
c++: error: unrecognized command line option ‘-Winconsistent-missing-destructor-override’
c++: error: unrecognized command line option ‘-Wcomma’; did you mean ‘-Wcomment’?
make[2]: *** [CMakeFiles/ColibriGui.dir/build.make:102: CMakeFiles/ColibriGui.dir/src/ColibriGui/ColibriEditbox.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:206: CMakeFiles/ColibriGui.dir/all] Error 2
make: *** [Makefile:106: all] Error 2
```