### PR TITLE
Fixed build on MacOS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ if( NOT COLIBRIGUI_LIB_ONLY )
 else()
 	add_recursive( ./src/ColibriGui SOURCES )
 	add_recursive( ./include/ColibriGui HEADERS )
+	list(REMOVE_ITEM SOURCES "${PROJECT_SOURCE_DIR}/src/ColibriGui/iOS/Colibri_iOS.mm")
 endif()
 
 if( APPLE )


### PR DESCRIPTION
add_recursive was also globbing the new ios .mm files and breaking the build. The ios mm files are included later on in the cmake file just for ios.

Tested new build with both MacOS and iOS build systems.